### PR TITLE
added definition of abs. Without it, it will cause error 3

### DIFF
--- a/apertium-jpn-eng.jpn-eng.dix
+++ b/apertium-jpn-eng.jpn-eng.dix
@@ -93,6 +93,7 @@
 
     <sdef n="compound-only-L" c="May only be the left-side of a compound"/>
     <sdef n="compound-R"      c="May be the right-side of a compound, or a full word"/>
+    <sdef n="abs" c="For things that don't have postpositions"/>
   </sdefs>
 
    <section id="main" type="standard">
@@ -125,7 +126,7 @@
       <e><p><l>8<s n="num"/></l><r>8<s n="num"/></r></p></e>
       <e><p><l>9<s n="num"/></l><r>9<s n="num"/></r></p></e>
       <!--SECTION: Nouns-->
-      <e><p><l>House<s n="n"/></l><r>家<s n="n"/><s n="sg"/><s n="abs"/></r></p></e> 
+      <e><p><l>House<s n="n"/></l><r>家<s n="n"/><s n="sg"/><s n="abs"/></r></p></e>
 
       <e><re>[.\?;:!…¿¶]</re><p><l><s n="sent"/></l><r><s n="sent"/></r></p></e>
       <e><re>,</re>          <p><l><s n="cm"/></l>  <r><s n="cm"/></r></p></e>


### PR DESCRIPTION
I did not add the definition on the commit before and it makes an error without it. 
I will merge this pull request shortly after making this. 